### PR TITLE
manifest: Remove network permission

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -8,7 +8,6 @@
     ],
     "command" : "solanum",
     "finish-args" : [
-        "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",


### PR DESCRIPTION
We have no use for the network permission. This was
provided by the template we used to create the app,
but it's not actually necessary.