### PR TITLE
Update the sassc URL

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -69,7 +69,7 @@
             "sources": [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/lazka/sassc/archive/3.6.1.tar.gz",
+                    "url" : "https://github.com/sass/sassc/archive/3.6.1.tar.gz",
                     "sha256": "8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60"
                 },
                 {


### PR DESCRIPTION
It seems the project moved, the previous URL doesn't exist anymore.