### PR TITLE
manifest: Update GTK4 and libadwaita

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -15,11 +15,7 @@
         "--device=dri"
     ],
     "build-options" : {
-        "append-path" : "/usr/lib/sdk/rust-stable/bin",
-        "env" : {
-            "CARGO_HOME" : "/run/build/solanum/cargo",
-            "RUSTFLAGS" : "-L=/app/lib"
-        }
+        "append-path" : "/usr/lib/sdk/rust-stable/bin"
     },
     "cleanup" : [
         "/include",
@@ -67,6 +63,36 @@
             ]
         },
         {
+            "name" : "pango",
+            "buildsystem": "meson",
+            "config-opts" : [
+                "-Dintrospection=disabled"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://gitlab.gnome.org/GNOME/pango/-/archive/1.50.3/pango-1.50.3.tar.gz",
+                    "sha256" : "4a8b0cf33d5f9ecaa9cd99dd72703d5c4c53bc58df64dd9538493bb4356ab691"
+                }
+            ]
+        },
+        {
+            "name" : "gtk",
+            "buildsystem": "meson",
+            "config-opts" : [
+                "-Dbuild-examples=false",
+                "-Dbuild-tests=false",
+                "-Dintrospection=disabled"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gtk/4.6/gtk-4.6.0.tar.xz",
+                    "sha256" : "782d5951fbfd585fc9ec76c09d07e28e6014c72db001fb567fff217fb96e4d8c"
+                }
+            ]
+        },
+        {
             "name" : "libadwaita",
             "buildsystem": "meson",
             "config-opts" : [
@@ -76,9 +102,9 @@
             ],
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "commit" : "905c3c4e27eabc94bcbe281e73bb2add5afd8e04"
+                    "type" : "archive",
+                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita/-/archive/1.0.0/libadwaita-1.0.0.tar.gz",
+                    "sha256" : "47c77d3e4703f0ce519dd8d4da24e94cad266b2b40f07cfaf9276f0f88aa4651"
                 }
             ]
         },


### PR DESCRIPTION
Now that libadwaita 1.0 is out, we should
use that and the required versions of GTK
and pango.