### PR TITLE
Manifest: Upgrade runtime-version to GNOME 44

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Solanum",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "42",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
runtime org.gnome.Platform branch 42 is end-of-life and 44 is working.
![image](https://user-images.githubusercontent.com/54215258/230400346-d054d7c3-2ca4-4dea-8f4d-7e1a8ef372bc.png)
