### PR TITLE
runtime: Update to 48

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -1,7 +1,7 @@
 {
     "id" : "org.gnome.Solanum",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -42,7 +42,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.10.0"
+                    "tag": "v0.16.0"
                 }
             ]
         },


### PR DESCRIPTION
Without the updating blueprint-compiler one gets a build error:

```
FAILED: data
/app/bin/blueprint-compiler batch-compile data/. ../data ../data/gtk/help-overlay.blp ../data/ui/preferences-window.blp ../data/ui/window.blp
Traceback (most recent call last):
  File "/app/bin/blueprint-compiler", line 38, in <module>
    from blueprintcompiler import main
  File "/app/lib/python3.12/site-packages/blueprintcompiler/main.py", line 27, in <module>
    from . import decompiler, interactive_port, parser, tokenizer
  File "/app/lib/python3.12/site-packages/blueprintcompiler/decompiler.py", line 25, in <module>
    from .gir import *
  File "/app/lib/python3.12/site-packages/blueprintcompiler/gir.py", line 27, in <module>
    gi.require_version("GIRepository", "2.0")
  File "/usr/lib/python3.12/site-packages/gi/__init__.py", line 132, in require_version
    raise ValueError('Namespace %s not available for version %s' %
ValueError: Namespace GIRepository not available for version 2.0
```