### PR TITLE
Update runtime to 50

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -1,7 +1,7 @@
 {
     "id" : "org.gnome.Solanum",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "48",
+    "runtime-version" : "50",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -18,20 +18,6 @@
         "append-path" : "/usr/lib/sdk/rust-stable/bin"
     },
     "modules" : [
-        {
-            "name": "blueprint-compiler",
-            "cleanup": [
-                "*"
-            ],
-            "buildsystem": "meson",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.16.0"
-                }
-            ]
-        },
         {
             "name" : "solanum",
             "buildsystem" : "meson",


### PR DESCRIPTION
- Update runtime to 50
- Drop blueprint-compiler module, which is already provided by the runtime.